### PR TITLE
Fix: Handle refresh token validation in AuthService

### DIFF
--- a/Club_System_API/Club_System_API.csproj
+++ b/Club_System_API/Club_System_API.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="Vonage" Version="6.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Migrations\" />
+  </ItemGroup>
+
 </Project>

--- a/Club_System_API/Migrations/20250715024430_InitialCreate.Designer.cs
+++ b/Club_System_API/Migrations/20250715024430_InitialCreate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Club_System_API.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250715024430_InitialCreate")]
+    partial class InitialCreate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Club_System_API/Migrations/20250715024430_InitialCreate.cs
+++ b/Club_System_API/Migrations/20250715024430_InitialCreate.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Club_System_API.Migrations
 {
     /// <inheritdoc />
-    public partial class initialCreate : Migration
+    public partial class InitialCreate : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -536,7 +536,7 @@ namespace Club_System_API.Migrations
             migrationBuilder.InsertData(
                 table: "AspNetUsers",
                 columns: new[] { "Id", "AccessFailedCount", "Birth_Of_Date", "ConcurrencyStamp", "Email", "EmailConfirmed", "FirstName", "Image", "ImageContentType", "IsDisabled", "JoinedAt", "LastName", "LockoutEnabled", "LockoutEnd", "MembershipId", "MembershipNumber", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "SecurityStamp", "TwoFactorEnabled", "UserName" },
-                values: new object[] { "6dc6528a-b280-4770-9eae-82671ee81ef7", 0, new DateOnly(2001, 12, 20), "99d2bbc6-bc54-4248-a172-a77de3ae4430", null, false, "Club System", null, null, false, new DateOnly(2025, 7, 14), "Admin", false, null, null, "Admin7", null, "ADMIN7", "AQAAAAIAAYagAAAAEG11fXlkvcGxeUaPMcHd42YNq9TZKK3UfeGAXgrhHVQTIaDq50veaZghpOpmlPQ4cg==", "01120443096", true, "55BF92C9EF0249CDA210D85D1A851BC9", false, "Admin7" });
+                values: new object[] { "6dc6528a-b280-4770-9eae-82671ee81ef7", 0, new DateOnly(2001, 12, 20), "99d2bbc6-bc54-4248-a172-a77de3ae4430", null, false, "Club System", null, null, false, new DateOnly(2025, 7, 15), "Admin", false, null, null, "Admin7", null, "ADMIN7", "AQAAAAIAAYagAAAAEG11fXlkvcGxeUaPMcHd42YNq9TZKK3UfeGAXgrhHVQTIaDq50veaZghpOpmlPQ4cg==", "01120443096", true, "55BF92C9EF0249CDA210D85D1A851BC9", false, "Admin7" });
 
             migrationBuilder.InsertData(
                 table: "AspNetUserRoles",

--- a/Club_System_API/Migrations/20250715033039_AddRefreshTokenTable.Designer.cs
+++ b/Club_System_API/Migrations/20250715033039_AddRefreshTokenTable.Designer.cs
@@ -11,8 +11,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Club_System_API.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250714011322_initialCreate")]
-    partial class initialCreate
+    [Migration("20250715033039_AddRefreshTokenTable")]
+    partial class AddRefreshTokenTable
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -129,7 +129,7 @@ namespace Club_System_API.Migrations
                             EmailConfirmed = false,
                             FirstName = "Club System",
                             IsDisabled = false,
-                            JoinedAt = new DateOnly(2025, 7, 14),
+                            JoinedAt = new DateOnly(2025, 7, 15),
                             LastName = "Admin",
                             LockoutEnabled = false,
                             MembershipNumber = "Admin7",

--- a/Club_System_API/Migrations/20250715033039_AddRefreshTokenTable.cs
+++ b/Club_System_API/Migrations/20250715033039_AddRefreshTokenTable.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Club_System_API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Club_System_API/Services/Authentication/AuthService.cs
+++ b/Club_System_API/Services/Authentication/AuthService.cs
@@ -134,11 +134,11 @@ namespace Club_System_API.Services.Authentication
                 return Result.Failure<AuthResponse>(UserErrors.LockedUser);
 
             var userRefreshToken = await _context.RefreshTokens
-                .Where(rt => rt.ApplicationUserId == user.Id && rt.Token == refreshToken && rt.IsActive)
-                .FirstOrDefaultAsync();
-
-            if (userRefreshToken is null)
+    .Where(rt => rt.ApplicationUserId == user.Id && rt.Token == refreshToken)
+    .FirstOrDefaultAsync();
+            if (userRefreshToken == null || !userRefreshToken.IsActive)
                 return Result.Failure<AuthResponse>(UserErrors.InvalidRefreshToken);
+
 
             userRefreshToken.RevokedOn = DateTime.UtcNow;
             _context.RefreshTokens.Update(userRefreshToken);

--- a/Club_System_API/Services/Authentication/AuthService.cs
+++ b/Club_System_API/Services/Authentication/AuthService.cs
@@ -43,15 +43,16 @@ namespace Club_System_API.Services.Authentication
                 var refreshToken = GenerateRefreshToken();
                 var refreshTokenExpiration = DateTime.UtcNow.AddDays(_refreshTokenExpiryDays);
 
-                user.RefreshTokens.Add(new RefreshToken
+                // ✅ تم التعديل هنا
+                await _context.RefreshTokens.AddAsync(new RefreshToken
                 {
                     Token = refreshToken,
-                    ExpiresOn = refreshTokenExpiration
+                    ExpiresOn = refreshTokenExpiration,
+                    ApplicationUserId = user.Id
                 });
 
-                await _userManager.UpdateAsync(user);
+                await _context.SaveChangesAsync();
 
-                // ✅ Get Latest Membership
                 MembershipDetailsDto? membershipDto = null;
 
                 var userMembership = await _context.UserMemberships
@@ -73,7 +74,6 @@ namespace Club_System_API.Services.Authentication
                     );
                 }
 
-                // ✅ Services
                 var bookings = await _context.Bookings
                     .Include(b => b.Appointment)
                         .ThenInclude(a => a.Service)
@@ -133,26 +133,31 @@ namespace Club_System_API.Services.Authentication
             if (user.LockoutEnd > DateTime.UtcNow)
                 return Result.Failure<AuthResponse>(UserErrors.LockedUser);
 
-            var userRefreshToken = user.RefreshTokens.SingleOrDefault(x => x.Token == refreshToken && x.IsActive);
+            var userRefreshToken = await _context.RefreshTokens
+                .Where(rt => rt.ApplicationUserId == user.Id && rt.Token == refreshToken && rt.IsActive)
+                .FirstOrDefaultAsync();
+
             if (userRefreshToken is null)
                 return Result.Failure<AuthResponse>(UserErrors.InvalidRefreshToken);
 
             userRefreshToken.RevokedOn = DateTime.UtcNow;
+            _context.RefreshTokens.Update(userRefreshToken);
 
             var userRoles = await _userManager.GetRolesAsync(user);
             var (newToken, expiresIn) = _jwtProvider.GenerateToken(user, userRoles);
             var newRefreshToken = GenerateRefreshToken();
             var refreshTokenExpiration = DateTime.UtcNow.AddDays(_refreshTokenExpiryDays);
 
-            user.RefreshTokens.Add(new RefreshToken
+            // ✅ تم التعديل هنا
+            await _context.RefreshTokens.AddAsync(new RefreshToken
             {
                 Token = newRefreshToken,
-                ExpiresOn = refreshTokenExpiration
+                ExpiresOn = refreshTokenExpiration,
+                ApplicationUserId = user.Id
             });
 
-            await _userManager.UpdateAsync(user);
+            await _context.SaveChangesAsync();
 
-            // ✅ Get Latest Membership
             MembershipDetailsDto? membershipDto = null;
 
             var userMembership = await _context.UserMemberships
@@ -174,7 +179,6 @@ namespace Club_System_API.Services.Authentication
                 );
             }
 
-            // ✅ Services
             var bookings = await _context.Bookings
                 .Include(b => b.Appointment)
                     .ThenInclude(a => a.Service)
@@ -236,12 +240,17 @@ namespace Club_System_API.Services.Authentication
             if (user is null)
                 return Result.Failure(UserErrors.InvalidJwtToken);
 
-            var userRefreshToken = user.RefreshTokens.SingleOrDefault(x => x.Token == refreshToken && x.IsActive);
+            var userRefreshToken = await _context.RefreshTokens
+                .Where(rt => rt.ApplicationUserId == user.Id && rt.Token == refreshToken && rt.IsActive)
+                .FirstOrDefaultAsync();
+
             if (userRefreshToken is null)
                 return Result.Failure(UserErrors.InvalidRefreshToken);
 
             userRefreshToken.RevokedOn = DateTime.UtcNow;
-            await _userManager.UpdateAsync(user);
+            _context.RefreshTokens.Update(userRefreshToken);
+
+            await _context.SaveChangesAsync();
             return Result.Success();
         }
 


### PR DESCRIPTION
- Fixed an issue with refresh token validation logic.
- Updated LINQ query to avoid using unmapped properties inside the database query.
- Tested and working now, returns 200 on valid token.